### PR TITLE
fix: Use print_color

### DIFF
--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -2,9 +2,20 @@
 
 # Common utility functions for scripts
 
+# Print colored text
+print_color() {
+    case $1 in
+        red)    echo -e "\033[31m$2\033[0m";;
+        green)  echo -e "\033[32m$2\033[0m";;
+        yellow) echo -e "\033[33m$2\033[0m";;
+        blue)   echo -e "\033[34m$2\033[0m";;
+        *)      echo "$2";;
+    esac
+}
+
 # Print error to stderr in red
 error() {
-    echo -e "\033[31mError: $*\033[0m" >&2
+    print_color red "Error: $*" >&2
 }
 
 # Print error and exit
@@ -26,25 +37,14 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
-# Print colored text
-print_color() {
-    case $1 in
-        red)    echo -e "\033[31m$2\033[0m";;
-        green)  echo -e "\033[32m$2\033[0m";;
-        yellow) echo -e "\033[33m$2\033[0m";;
-        blue)   echo -e "\033[34m$2\033[0m";;
-        *)      echo "$2";;
-    esac
-}
-
 # Print warning in yellow
 warning() {
-    echo -e "\033[33mWarning: $*\033[0m" >&2
+    print_color yellow "Warning: $*" >&2
 }
 
 # Print success in green
 success() {
-    echo -e "\033[32m✓ $*\033[0m"
+    print_color green "✓ $*"
 }
 
 # Run command with description


### PR DESCRIPTION
Also, make sure to quote path correctly in `set_source_and_root_dir`> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Addresses feedback on https://github.com/PostHog/template/pull/3

## Changes

Change `warning`, `error`, and `success` to use `print_color`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

manually