### PR TITLE
feat: Add find_port_process function to utils

### DIFF
--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -77,7 +77,10 @@ find_port_process() {
     local pid=""
     
     # Validate input
-    [ -n "$port" ] || return 0
+    if [ -z "$port" ]; then
+        echo "Error: Port number required" >&2
+        return 1
+    fi
     
     # Helper function to format output
     format_output() {


### PR DESCRIPTION
Cross-platform utility to find process using a specific port. Tries lsof first, then ss/netstat as fallbacks.
Returns "pid:process_name" format for easy parsing.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

A lot of scripts I write need to check ports before starting up services. This is a handy utility function to do this.

## Changes

Added a new function.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually.