### PR TITLE
chore: Remove `run_command` and simplify examples

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,56 +1,67 @@
 #!/usr/bin/env bash
 #/ Usage: bin/bootstrap
 #/ Description: Resolves all dependencies that the project requires to run
-#/ 
+#/
 #/ This script is idempotent and safe to run multiple times.
 
 source bin/helpers/_utils.sh
 set_source_and_root_dir
 parse_common_args "$@"
+set -e
 
 print_color blue "Bootstrapping project dependencies..."
 
 # Node.js
 if [ -f "package.json" ]; then
     if [ -f "package-lock.json" ]; then
-        run_command "npm ci" "Installing Node.js dependencies (locked)"
+        echo "→ Installing Node.js dependencies (locked)"
+        npm ci
     else
-        run_command "npm install" "Installing Node.js dependencies"
+        echo "→ Installing Node.js dependencies"
+        npm install
     fi
 fi
 
 # Python
 if [ -f "requirements.txt" ]; then
-    run_command "python3 -m pip install -r requirements.txt" "Installing Python dependencies"
+    echo "→ Installing Python dependencies"
+    python3 -m pip install -r requirements.txt
 elif [ -f "pyproject.toml" ]; then
     if command_exists poetry; then
-        run_command "poetry install" "Installing Python dependencies with Poetry"
+        echo "→ Installing Python dependencies with Poetry"
+        poetry install
     else
-        run_command "python3 -m pip install ." "Installing Python dependencies"
+        echo "→ Installing Python dependencies"
+        python3 -m pip install .
     fi
 elif [ -f "Pipfile" ]; then
     require_commands pipenv
-    run_command "pipenv install" "Installing Python dependencies with Pipenv"
+    echo "→ Installing Python dependencies with Pipenv"
+    pipenv install
 fi
 
 # Ruby
 if [ -f "Gemfile" ]; then
-    run_command "bundle install" "Installing Ruby dependencies"
+    echo "→ Installing Ruby dependencies"
+    bundle install
 fi
 
 # .NET
 if compgen -G "*.sln" > /dev/null; then
-    run_command "dotnet restore" "Restoring .NET dependencies"
+    echo "→ Restoring .NET dependencies"
+    dotnet restore
 fi
 
 # Go
 if [ -f "go.mod" ]; then
-    run_command "go mod download" "Downloading Go dependencies"
+    echo "→ Downloading Go dependencies"
+    go mod download
 fi
 
 # Rust
 if [ -f "Cargo.toml" ]; then
-    run_command "cargo fetch" "Fetching Rust dependencies"
+    echo "→ Fetching Rust dependencies"
+    cargo fetch
 fi
 
 print_color green "✓ Dependencies installed successfully"

--- a/bin/build
+++ b/bin/build
@@ -30,15 +30,17 @@ while (( "$#" )); do
     esac
 done
 
+set -e
+
 print_color blue "Building project..."
 
 # Node.js
 if [ -f "package.json" ] && grep -q '"build"' package.json; then
-    cmd="npm run build"
     if [ -n "$output" ]; then
         export BUILD_OUTPUT="$output"
     fi
-    run_command "$cmd" "Building Node.js project"
+    echo "→ Building Node.js project"
+    npm run build
 fi
 
 # TypeScript
@@ -47,22 +49,26 @@ if [ -f "tsconfig.json" ] && ! grep -q '"build"' package.json 2>/dev/null; then
     if [ -n "$output" ]; then
         cmd="$cmd --outDir $output"
     fi
-    run_command "$cmd" "Building TypeScript project"
+    echo "→ Building TypeScript project"
+    $cmd
 fi
 
 # Python
 if [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
     if [ -f "pyproject.toml" ] && command_exists poetry; then
-        run_command "poetry build" "Building Python package with Poetry"
+        echo "→ Building Python package with Poetry"
+        poetry build
     else
-        run_command "python3 -m build" "Building Python package"
+        echo "→ Building Python package"
+        python3 -m build
     fi
 fi
 
 # Ruby
 if [ -f "Gemfile" ] && [ -f "Rakefile" ]; then
     if grep -q "build" Rakefile; then
-        run_command "bundle exec rake build" "Building Ruby project"
+        echo "→ Building Ruby project"
+        bundle exec rake build
     fi
 fi
 
@@ -72,39 +78,44 @@ if compgen -G "*.sln" > /dev/null || compgen -G "*.csproj" > /dev/null; then
     if [ -n "$output" ]; then
         cmd="$cmd --output $output"
     fi
-    run_command "$cmd" "Building .NET project"
+    echo "→ Building .NET project"
+    $cmd
 fi
 
 # Go
 if [ -f "go.mod" ]; then
     output_file="${output:-./bin/app}"
     mkdir -p "$(dirname "$output_file")"
-    run_command "go build -o $output_file" "Building Go project"
+    echo "→ Building Go project"
+    go build -o "$output_file"
 fi
 
 # Rust
 if [ -f "Cargo.toml" ]; then
-    cmd="cargo build --release"
     if [ -n "$output" ]; then
         export CARGO_TARGET_DIR="$output"
     fi
-    run_command "$cmd" "Building Rust project"
+    echo "→ Building Rust project"
+    cargo build --release
 fi
 
 # Java/Maven
 if [ -f "pom.xml" ]; then
-    run_command "mvn clean package" "Building Maven project"
+    echo "→ Building Maven project"
+    mvn clean package
 fi
 
 # Java/Gradle
 if [ -f "build.gradle" ] || [ -f "build.gradle.kts" ]; then
-    run_command "./gradlew build" "Building Gradle project"
+    echo "→ Building Gradle project"
+    ./gradlew build
 fi
 
 # Docker
 if [ -f "Dockerfile" ]; then
     image_name="${PROJECT_NAME:-app}"
-    run_command "docker build -t $image_name ." "Building Docker image"
+    echo "→ Building Docker image"
+    docker build -t "$image_name" .
 fi
 
 print_color green "✓ Build complete"

--- a/bin/clean
+++ b/bin/clean
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #/ Usage: bin/clean
 #/ Description: Removes build artifacts and temporary files
-#/ 
+#/
 #/ This script removes common build artifacts, caches, and temporary files.
 #/ It's safe to run and won't delete source code or configuration.
 
@@ -14,68 +14,97 @@ print_color blue "Cleaning build artifacts and temporary files..."
 # Node.js
 if [ -d "node_modules" ]; then
     if [ -d "dist" ]; then
-        run_command "rm -rf dist" "Removing dist directory"
+        echo "→ Removing dist directory"
+        rm -rf dist
     fi
     if [ -d "build" ]; then
-        run_command "rm -rf build" "Removing build directory"
+        echo "→ Removing build directory"
+        rm -rf build
     fi
     if [ -d ".next" ]; then
-        run_command "rm -rf .next" "Removing Next.js build"
+        echo "→ Removing Next.js build"
+        rm -rf .next
     fi
     if [ -d "coverage" ]; then
-        run_command "rm -rf coverage" "Removing coverage reports"
+        echo "→ Removing coverage reports"
+        rm -rf coverage
     fi
-    run_command "rm -rf *.log" "Removing log files"
+    echo "→ Removing log files"
+    rm -rf ./*.log
 fi
 
 # Python
 if [ -d "__pycache__" ] || [ -d ".pytest_cache" ]; then
-    run_command "find . -type d -name '__pycache__' -exec rm -rf {} +" "Removing Python cache"
-    run_command "find . -type f -name '*.pyc' -delete" "Removing compiled Python files"
-    run_command "rm -rf .pytest_cache" "Removing pytest cache"
-    run_command "rm -rf .mypy_cache" "Removing mypy cache"
-    run_command "rm -rf .ruff_cache" "Removing ruff cache"
-    run_command "rm -rf dist build *.egg-info" "Removing Python build artifacts"
-    run_command "rm -rf .coverage coverage.xml htmlcov" "Removing coverage reports"
+    echo "→ Removing Python cache"
+    find . -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
+    echo "→ Removing compiled Python files"
+    find . -type f -name '*.pyc' -delete 2>/dev/null || true
+    echo "→ Removing pytest cache"
+    rm -rf .pytest_cache
+    echo "→ Removing mypy cache"
+    rm -rf .mypy_cache
+    echo "→ Removing ruff cache"
+    rm -rf .ruff_cache
+    echo "→ Removing Python build artifacts"
+    rm -rf dist build ./*.egg-info
+    echo "→ Removing coverage reports"
+    rm -rf .coverage coverage.xml htmlcov
 fi
 
 # Ruby
 if [ -f "Gemfile" ]; then
-    run_command "rm -rf coverage" "Removing coverage reports"
-    run_command "rm -rf .bundle" "Removing bundle config"
-    run_command "rm -rf vendor/bundle" "Removing vendored gems"
+    echo "→ Removing coverage reports"
+    rm -rf coverage
+    echo "→ Removing bundle config"
+    rm -rf .bundle
+    echo "→ Removing vendored gems"
+    rm -rf vendor/bundle
 fi
 
 # .NET
 if compgen -G "*.sln" > /dev/null || compgen -G "*.csproj" > /dev/null; then
-    run_command "find . -type d -name 'bin' -exec rm -rf {} +" "Removing bin directories"
-    run_command "find . -type d -name 'obj' -exec rm -rf {} +" "Removing obj directories"
-    run_command "rm -rf TestResults" "Removing test results"
+    echo "→ Removing bin directories"
+    find . -type d -name 'bin' -exec rm -rf {} + 2>/dev/null || true
+    echo "→ Removing obj directories"
+    find . -type d -name 'obj' -exec rm -rf {} + 2>/dev/null || true
+    echo "→ Removing test results"
+    rm -rf TestResults
 fi
 
 # Go
 if [ -f "go.mod" ]; then
-    run_command "go clean -cache -testcache" "Cleaning Go cache"
-    run_command "rm -rf bin" "Removing bin directory"
+    echo "→ Cleaning Go cache"
+    go clean -cache -testcache
+    echo "→ Removing bin directory"
+    rm -rf bin
 fi
 
 # Rust
 if [ -f "Cargo.toml" ]; then
-    run_command "cargo clean" "Cleaning Rust build"
+    echo "→ Cleaning Rust build"
+    cargo clean
 fi
 
 # Java
 if [ -f "pom.xml" ] || [ -f "build.gradle" ]; then
-    run_command "rm -rf target" "Removing Maven target"
-    run_command "rm -rf build" "Removing Gradle build"
-    run_command "rm -rf .gradle" "Removing Gradle cache"
+    echo "→ Removing Maven target"
+    rm -rf target
+    echo "→ Removing Gradle build"
+    rm -rf build
+    echo "→ Removing Gradle cache"
+    rm -rf .gradle
 fi
 
 # General
-run_command "rm -rf .DS_Store" "Removing macOS files"
-run_command "rm -rf .vscode/settings.json" "Removing VS Code settings"
-run_command "rm -rf .idea" "Removing IntelliJ IDEA files"
-run_command "find . -name '*.swp' -delete" "Removing vim swap files"
-run_command "find . -name '*~' -delete" "Removing backup files"
+echo "→ Removing macOS files"
+rm -rf .DS_Store
+echo "→ Removing VS Code settings"
+rm -rf .vscode/settings.json
+echo "→ Removing IntelliJ IDEA files"
+rm -rf .idea
+echo "→ Removing vim swap files"
+find . -name '*.swp' -delete 2>/dev/null || true
+echo "→ Removing backup files"
+find . -name '*~' -delete 2>/dev/null || true
 
 print_color green "✓ Clean complete"

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #/ Usage: bin/console
 #/ Description: Starts an interactive console/REPL for the project
-#/ 
+#/
 #/ This provides an interactive environment with the project loaded.
 
 source bin/helpers/_utils.sh
@@ -13,43 +13,53 @@ print_color blue "Starting interactive console..."
 # Node.js
 if [ -f "package.json" ]; then
     if grep -q '"console"' package.json; then
-        run_command "npm run console" "Starting custom console"
+        echo "→ Starting custom console"
+        exec npm run console
     else
-        run_command "node" "Starting Node.js REPL"
+        echo "→ Starting Node.js REPL"
+        exec node
     fi
 
 # Python
 elif [ -f "requirements.txt" ] || [ -f "pyproject.toml" ] || [ -f "Pipfile" ]; then
     if [ -f "manage.py" ]; then
         # Django shell
-        run_command "python3 manage.py shell" "Starting Django shell"
+        echo "→ Starting Django shell"
+        exec python3 manage.py shell
     elif command_exists ipython; then
-        run_command "ipython" "Starting IPython"
+        echo "→ Starting IPython"
+        exec ipython
     else
-        run_command "python3" "Starting Python REPL"
+        echo "→ Starting Python REPL"
+        exec python3
     fi
 
 # Ruby
 elif [ -f "Gemfile" ]; then
     if grep -q "rails" Gemfile && [ -f "bin/rails" ]; then
-        run_command "bin/rails console" "Starting Rails console"
+        echo "→ Starting Rails console"
+        exec bin/rails console
     elif command_exists irb; then
-        run_command "bundle exec irb" "Starting Ruby IRB"
+        echo "→ Starting Ruby IRB"
+        exec bundle exec irb
     fi
 
 # .NET
 elif compgen -G "*.csproj" > /dev/null; then
     if command_exists dotnet-script; then
-        run_command "dotnet-script" "Starting C# interactive"
+        echo "→ Starting C# interactive"
+        exec dotnet-script
     else
         print_color yellow "Install dotnet-script for interactive C#: dotnet tool install -g dotnet-script"
-        run_command "dotnet run" "Running project"
+        echo "→ Running project"
+        exec dotnet run
     fi
 
 # Go
 elif [ -f "go.mod" ]; then
     if command_exists gore; then
-        run_command "gore" "Starting Go REPL"
+        echo "→ Starting Go REPL"
+        exec gore
     else
         print_color yellow "Install gore for Go REPL: go install github.com/x-motemen/gore/cmd/gore@latest"
     fi
@@ -57,7 +67,8 @@ elif [ -f "go.mod" ]; then
 # Rust
 elif [ -f "Cargo.toml" ]; then
     if command_exists evcxr; then
-        run_command "evcxr" "Starting Rust REPL"
+        echo "→ Starting Rust REPL"
+        exec evcxr
     else
         print_color yellow "Install evcxr for Rust REPL: cargo install evcxr_repl"
     fi

--- a/bin/fmt
+++ b/bin/fmt
@@ -47,17 +47,19 @@ if [ -f "package.json" ]; then
         else
             cmd="$cmd --write"
         fi
-        if ! run_command "$cmd ." "Formatting JavaScript/TypeScript"; then
+        echo "→ Formatting JavaScript/TypeScript"
+        if ! $cmd .; then
             success=false
         fi
     fi
-    
+
     if grep -q '"eslint"' package.json || [ -f ".eslintrc" ] || [ -f ".eslintrc.json" ]; then
         cmd="npx eslint"
         if ! $check; then
             cmd="$cmd --fix"
         fi
-        if ! run_command "$cmd ." "Linting JavaScript/TypeScript"; then
+        echo "→ Linting JavaScript/TypeScript"
+        if ! $cmd .; then
             success=false
         fi
     fi
@@ -70,7 +72,8 @@ if command_exists black || command_exists ruff; then
         if $check; then
             cmd="$cmd --check"
         fi
-        if ! run_command "$cmd ." "Formatting Python with ruff"; then
+        echo "→ Formatting Python with ruff"
+        if ! $cmd .; then
             success=false
         fi
     elif command_exists black; then
@@ -78,17 +81,19 @@ if command_exists black || command_exists ruff; then
         if $check; then
             cmd="$cmd --check"
         fi
-        if ! run_command "$cmd ." "Formatting Python with black"; then
+        echo "→ Formatting Python with black"
+        if ! $cmd .; then
             success=false
         fi
     fi
-    
+
     if command_exists isort; then
         cmd="isort"
         if $check; then
             cmd="$cmd --check-only"
         fi
-        if ! run_command "$cmd ." "Sorting Python imports"; then
+        echo "→ Sorting Python imports"
+        if ! $cmd .; then
             success=false
         fi
     fi
@@ -100,7 +105,8 @@ if [ -f "Gemfile" ] && command_exists rubocop; then
     if ! $check; then
         cmd="$cmd --auto-correct"
     fi
-    if ! run_command "$cmd" "Formatting Ruby"; then
+    echo "→ Formatting Ruby"
+    if ! $cmd; then
         success=false
     fi
 fi
@@ -111,18 +117,20 @@ if command_exists dotnet && (compgen -G "*.sln" > /dev/null || compgen -G "*.csp
     if $check; then
         args+=("--verify-no-changes")
     fi
-    
+
     # Find solution or project file
     if compgen -G "*.sln" > /dev/null; then
-        target=$(ls *.sln | head -1)
+        target=$(ls ./*.sln | head -1)
     else
         target="."
     fi
-    
-    if ! run_command "dotnet format whitespace \"$target\" ${args[*]}" "Formatting .NET whitespace"; then
+
+    echo "→ Formatting .NET whitespace"
+    if ! dotnet format whitespace "$target" "${args[@]}"; then
         success=false
     fi
-    if ! run_command "dotnet format style \"$target\" ${args[*]}" "Formatting .NET style"; then
+    echo "→ Formatting .NET style"
+    if ! dotnet format style "$target" "${args[@]}"; then
         success=false
     fi
 fi
@@ -136,9 +144,10 @@ if [ -f "go.mod" ] && command_exists gofmt; then
             success=false
         fi
     else
-        run_command "gofmt -w ." "Formatting Go"
+        echo "→ Formatting Go"
+        gofmt -w .
     fi
-    
+
     if command_exists goimports; then
         if $check; then
             if [ -n "$(goimports -l .)" ]; then
@@ -146,7 +155,8 @@ if [ -f "go.mod" ] && command_exists gofmt; then
                 success=false
             fi
         else
-            run_command "goimports -w ." "Formatting Go imports"
+            echo "→ Formatting Go imports"
+            goimports -w .
         fi
     fi
 fi
@@ -157,7 +167,8 @@ if [ -f "Cargo.toml" ] && command_exists cargo; then
     if $check; then
         cmd="$cmd -- --check"
     fi
-    if ! run_command "$cmd" "Formatting Rust"; then
+    echo "→ Formatting Rust"
+    if ! $cmd; then
         success=false
     fi
 fi
@@ -170,7 +181,8 @@ if command_exists shfmt; then
     else
         cmd="$cmd -w"
     fi
-    if ! run_command "$cmd ." "Formatting shell scripts"; then
+    echo "→ Formatting shell scripts"
+    if ! $cmd .; then
         success=false
     fi
 fi

--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -47,13 +47,6 @@ success() {
     print_color green "✓ $*"
 }
 
-# Run command with description
-run_command() {
-    echo "→ ${2:-Running command}"
-    [ "$VERBOSE" ] && echo "  $1"
-    $1 || fatal "Command failed: $1"
-}
-
 # Check required commands exist
 require_commands() {
     local missing=()

--- a/bin/lint
+++ b/bin/lint
@@ -41,13 +41,15 @@ if [ -f "package.json" ]; then
         if $fix; then
             cmd="$cmd --fix"
         fi
-        if ! run_command "$cmd" "Linting JavaScript/TypeScript"; then
+        echo "→ Linting JavaScript/TypeScript"
+        if ! $cmd; then
             success=false
         fi
     fi
-    
+
     if command_exists tsc && [ -f "tsconfig.json" ]; then
-        if ! run_command "npx tsc --noEmit" "Type checking TypeScript"; then
+        echo "→ Type checking TypeScript"
+        if ! npx tsc --noEmit; then
             success=false
         fi
     fi
@@ -59,21 +61,25 @@ if command_exists ruff; then
     if $fix; then
         cmd="$cmd --fix"
     fi
-    if ! run_command "$cmd ." "Linting Python with ruff"; then
+    echo "→ Linting Python with ruff"
+    if ! $cmd .; then
         success=false
     fi
 elif command_exists flake8; then
-    if ! run_command "flake8 ." "Linting Python with flake8"; then
+    echo "→ Linting Python with flake8"
+    if ! flake8 .; then
         success=false
     fi
 elif command_exists pylint; then
-    if ! run_command "pylint **/*.py" "Linting Python with pylint"; then
+    echo "→ Linting Python with pylint"
+    if ! pylint ./**/*.py; then
         success=false
     fi
 fi
 
 if command_exists mypy && [ -f "mypy.ini" ]; then
-    if ! run_command "mypy ." "Type checking Python"; then
+    echo "→ Type checking Python"
+    if ! mypy .; then
         success=false
     fi
 fi
@@ -84,7 +90,8 @@ if [ -f "Gemfile" ] && command_exists rubocop; then
     if $fix; then
         cmd="$cmd --auto-correct"
     fi
-    if ! run_command "$cmd" "Linting Ruby"; then
+    echo "→ Linting Ruby"
+    if ! $cmd; then
         success=false
     fi
 fi
@@ -96,11 +103,13 @@ if [ -f "go.mod" ]; then
         if $fix; then
             cmd="$cmd --fix"
         fi
-        if ! run_command "$cmd" "Linting Go with golangci-lint"; then
+        echo "→ Linting Go with golangci-lint"
+        if ! $cmd; then
             success=false
         fi
     else
-        if ! run_command "go vet ./..." "Running go vet"; then
+        echo "→ Running go vet"
+        if ! go vet ./...; then
             success=false
         fi
     fi
@@ -108,28 +117,32 @@ fi
 
 # Rust
 if [ -f "Cargo.toml" ] && command_exists cargo; then
-    if ! run_command "cargo clippy -- -D warnings" "Linting Rust with clippy"; then
+    echo "→ Linting Rust with clippy"
+    if ! cargo clippy -- -D warnings; then
         success=false
     fi
 fi
 
 # Shell scripts
 if command_exists shellcheck; then
-    if ! run_command "shellcheck bin/*" "Linting shell scripts"; then
+    echo "→ Linting shell scripts"
+    if ! shellcheck bin/*; then
         success=false
     fi
 fi
 
 # Markdown
 if command_exists markdownlint; then
-    if ! run_command "markdownlint '**/*.md'" "Linting Markdown"; then
+    echo "→ Linting Markdown"
+    if ! markdownlint '**/*.md'; then
         success=false
     fi
 fi
 
 # YAML
 if command_exists yamllint; then
-    if ! run_command "yamllint ." "Linting YAML"; then
+    echo "→ Linting YAML"
+    if ! yamllint .; then
         success=false
     fi
 fi

--- a/bin/server
+++ b/bin/server
@@ -1,64 +1,76 @@
 #!/usr/bin/env bash
 #/ Usage: bin/server
 #/ Description: Starts all necessary services (database, cache, etc.)
-#/ 
+#/
 #/ This script starts background services required by the application.
 #/ Use bin/start to run the application itself.
 
 source bin/helpers/_utils.sh
 set_source_and_root_dir
 parse_common_args "$@"
+set -e
 
 print_color blue "Starting services..."
 
 # Docker Compose services
 if [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ]; then
-    run_command "docker-compose up -d db redis" "Starting Docker services"
+    echo "→ Starting Docker services"
+    docker-compose up -d db redis
 
 # Individual services
 else
     # PostgreSQL
     if grep -q "postgres" Gemfile 2>/dev/null || grep -q "psycopg" requirements.txt 2>/dev/null || grep -q "pg" package.json 2>/dev/null; then
         if command_exists pg_ctl; then
-            run_command "pg_ctl start" "Starting PostgreSQL"
+            echo "→ Starting PostgreSQL"
+            pg_ctl start
         elif command_exists brew; then
-            run_command "brew services start postgresql" "Starting PostgreSQL"
+            echo "→ Starting PostgreSQL"
+            brew services start postgresql
         fi
     fi
-    
+
     # MySQL
     if grep -q "mysql" Gemfile 2>/dev/null || grep -q "mysql" requirements.txt 2>/dev/null || grep -q "mysql" package.json 2>/dev/null; then
         if command_exists mysql.server; then
-            run_command "mysql.server start" "Starting MySQL"
+            echo "→ Starting MySQL"
+            mysql.server start
         elif command_exists brew; then
-            run_command "brew services start mysql" "Starting MySQL"
+            echo "→ Starting MySQL"
+            brew services start mysql
         fi
     fi
-    
+
     # Redis
     if grep -q "redis" Gemfile 2>/dev/null || grep -q "redis" requirements.txt 2>/dev/null || grep -q "redis" package.json 2>/dev/null; then
         if command_exists redis-server; then
-            run_command "redis-server --daemonize yes" "Starting Redis"
+            echo "→ Starting Redis"
+            redis-server --daemonize yes
         elif command_exists brew; then
-            run_command "brew services start redis" "Starting Redis"
+            echo "→ Starting Redis"
+            brew services start redis
         fi
     fi
-    
+
     # MongoDB
     if grep -q "mongo" package.json 2>/dev/null || grep -q "pymongo" requirements.txt 2>/dev/null; then
         if command_exists mongod; then
-            run_command "mongod --fork --logpath /var/log/mongodb.log" "Starting MongoDB"
+            echo "→ Starting MongoDB"
+            mongod --fork --logpath /var/log/mongodb.log
         elif command_exists brew; then
-            run_command "brew services start mongodb-community" "Starting MongoDB"
+            echo "→ Starting MongoDB"
+            brew services start mongodb-community
         fi
     fi
-    
+
     # Elasticsearch
     if grep -q "elasticsearch" Gemfile 2>/dev/null || grep -q "elasticsearch" requirements.txt 2>/dev/null || grep -q "elasticsearch" package.json 2>/dev/null; then
         if command_exists elasticsearch; then
-            run_command "elasticsearch -d" "Starting Elasticsearch"
+            echo "→ Starting Elasticsearch"
+            elasticsearch -d
         elif command_exists brew; then
-            run_command "brew services start elasticsearch" "Starting Elasticsearch"
+            echo "→ Starting Elasticsearch"
+            brew services start elasticsearch
         fi
     fi
 fi

--- a/bin/start
+++ b/bin/start
@@ -41,14 +41,15 @@ print_color blue "Starting application in $env mode..."
 # Node.js
 if [ -f "package.json" ]; then
     if grep -q '"start"' package.json; then
-        cmd="npm start"
         if [ -n "$port" ]; then
             export PORT="$port"
         fi
         export NODE_ENV="$env"
-        run_command "$cmd" "Starting Node.js application"
+        echo "→ Starting Node.js application"
+        exec npm start
     elif grep -q '"dev"' package.json; then
-        run_command "npm run dev" "Starting Node.js application (dev mode)"
+        echo "→ Starting Node.js application (dev mode)"
+        exec npm run dev
     fi
 fi
 
@@ -59,7 +60,8 @@ if [ -f "manage.py" ]; then
     if [ -n "$port" ]; then
         cmd="$cmd 0.0.0.0:$port"
     fi
-    run_command "$cmd" "Starting Django application"
+    echo "→ Starting Django application"
+    exec $cmd
 elif [ -f "app.py" ] || [ -f "main.py" ]; then
     # Flask/FastAPI
     if grep -q "flask" requirements.txt 2>/dev/null; then
@@ -69,15 +71,18 @@ elif [ -f "app.py" ] || [ -f "main.py" ]; then
         if [ -n "$port" ]; then
             cmd="$cmd --port $port"
         fi
-        run_command "$cmd" "Starting Flask application"
+        echo "→ Starting Flask application"
+        exec $cmd
     elif grep -q "fastapi" requirements.txt 2>/dev/null; then
         cmd="uvicorn main:app --reload"
         if [ -n "$port" ]; then
             cmd="$cmd --port $port"
         fi
-        run_command "$cmd" "Starting FastAPI application"
+        echo "→ Starting FastAPI application"
+        exec $cmd
     else
-        run_command "python3 ${MAIN_FILE:-main.py}" "Starting Python application"
+        echo "→ Starting Python application"
+        exec python3 "${MAIN_FILE:-main.py}"
     fi
 fi
 
@@ -89,39 +94,42 @@ if [ -f "Gemfile" ]; then
         if [ -n "$port" ]; then
             cmd="$cmd -p $port"
         fi
-        run_command "$cmd" "Starting Ruby application"
+        echo "→ Starting Ruby application"
+        exec $cmd
     elif grep -q "rails" Gemfile; then
         cmd="bundle exec rails server"
         if [ -n "$port" ]; then
             cmd="$cmd -p $port"
         fi
-        run_command "$cmd" "Starting Rails application"
+        echo "→ Starting Rails application"
+        exec $cmd
     fi
 fi
 
 # .NET
 if compgen -G "*.csproj" > /dev/null; then
-    project=$(ls *.csproj | grep -v Test | head -1)
-    cmd="dotnet run --project $project"
+    project=$(ls ./*.csproj | grep -v Test | head -1)
     if [ -n "$port" ]; then
         export ASPNETCORE_URLS="http://localhost:$port"
     fi
     export ASPNETCORE_ENVIRONMENT="${env^}"  # Capitalize first letter
-    run_command "$cmd" "Starting .NET application"
+    echo "→ Starting .NET application"
+    exec dotnet run --project "$project"
 fi
 
 # Go
 if [ -f "go.mod" ] && [ -f "main.go" ]; then
-    cmd="go run main.go"
     if [ -n "$port" ]; then
         export PORT="$port"
     fi
-    run_command "$cmd" "Starting Go application"
+    echo "→ Starting Go application"
+    exec go run main.go
 fi
 
 # Docker Compose
 if [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ]; then
-    run_command "docker-compose up" "Starting with Docker Compose"
+    echo "→ Starting with Docker Compose"
+    exec docker-compose up
 fi
 
 print_color green "✓ Application started"

--- a/bin/test
+++ b/bin/test
@@ -38,6 +38,8 @@ while (( "$#" )); do
     esac
 done
 
+set -e
+
 print_color blue "Running tests..."
 
 # Node.js
@@ -50,7 +52,8 @@ if [ -f "package.json" ]; then
         if $watch && grep -q '"test:watch"' package.json; then
             cmd="npm run test:watch"
         fi
-        run_command "$cmd ${test_args[*]}" "Running Node.js tests"
+        echo "→ Running Node.js tests"
+        $cmd "${test_args[@]}"
     fi
 fi
 
@@ -64,19 +67,22 @@ if [ -f "pytest.ini" ] || [ -f "setup.cfg" ] || [ -f "pyproject.toml" ]; then
         if $watch && command_exists ptw; then
             cmd="ptw"
         fi
-        run_command "$cmd ${test_args[*]}" "Running Python tests"
+        echo "→ Running Python tests"
+        $cmd "${test_args[@]}"
     fi
 elif [ -d "tests" ] || [ -d "test" ]; then
-    run_command "python3 -m unittest discover ${test_args[*]}" "Running Python tests"
+    echo "→ Running Python tests"
+    python3 -m unittest discover "${test_args[@]}"
 fi
 
 # Ruby
 if [ -f "Gemfile" ] && grep -q "rspec" Gemfile; then
     cmd="bundle exec rspec"
     if $coverage; then
-        cmd="COVERAGE=true $cmd"
+        export COVERAGE=true
     fi
-    run_command "$cmd ${test_args[*]}" "Running Ruby tests"
+    echo "→ Running Ruby tests"
+    $cmd "${test_args[@]}"
 fi
 
 # .NET
@@ -85,7 +91,8 @@ if compgen -G "*.sln" > /dev/null || compgen -G "*Tests.csproj" > /dev/null; the
     if $coverage; then
         cmd="$cmd --collect:\"XPlat Code Coverage\""
     fi
-    run_command "$cmd ${test_args[*]}" "Running .NET tests"
+    echo "→ Running .NET tests"
+    $cmd "${test_args[@]}"
 fi
 
 # Go
@@ -97,7 +104,8 @@ if [ -f "go.mod" ]; then
     if [ "$VERBOSE" = "1" ]; then
         cmd="$cmd -v"
     fi
-    run_command "$cmd ${test_args[*]}" "Running Go tests"
+    echo "→ Running Go tests"
+    $cmd "${test_args[@]}"
 fi
 
 # Rust
@@ -106,7 +114,8 @@ if [ -f "Cargo.toml" ]; then
     if [ "$VERBOSE" = "1" ]; then
         cmd="$cmd --verbose"
     fi
-    run_command "$cmd ${test_args[*]}" "Running Rust tests"
+    echo "→ Running Rust tests"
+    $cmd "${test_args[@]}"
 fi
 
 print_color green "✓ Tests completed"

--- a/bin/update
+++ b/bin/update
@@ -1,44 +1,53 @@
 #!/usr/bin/env bash
 #/ Usage: bin/update
 #/ Description: Updates project dependencies to their latest versions
-#/ 
+#/
 #/ This script updates dependencies while respecting version constraints.
 #/ Always run tests after updating to ensure nothing broke.
 
 source bin/helpers/_utils.sh
 set_source_and_root_dir
 parse_common_args "$@"
+set -e
 
 print_color blue "Updating project dependencies..."
 
 # Node.js
 if [ -f "package.json" ]; then
     if [ -f "package-lock.json" ]; then
-        run_command "npm update" "Updating Node.js dependencies"
-        run_command "npm audit fix" "Fixing security vulnerabilities"
+        echo "→ Updating Node.js dependencies"
+        npm update
+        echo "→ Fixing security vulnerabilities"
+        npm audit fix
     elif [ -f "yarn.lock" ]; then
-        run_command "yarn upgrade" "Updating Node.js dependencies with Yarn"
+        echo "→ Updating Node.js dependencies with Yarn"
+        yarn upgrade
     elif [ -f "pnpm-lock.yaml" ]; then
-        run_command "pnpm update" "Updating Node.js dependencies with pnpm"
+        echo "→ Updating Node.js dependencies with pnpm"
+        pnpm update
     fi
 fi
 
 # Python
 if [ -f "requirements.txt" ]; then
     if command_exists pip-compile; then
-        run_command "pip-compile --upgrade requirements.in" "Updating Python dependencies"
+        echo "→ Updating Python dependencies"
+        pip-compile --upgrade requirements.in
     else
         print_color yellow "Consider using pip-tools for better dependency management"
     fi
 elif [ -f "pyproject.toml" ] && command_exists poetry; then
-    run_command "poetry update" "Updating Python dependencies with Poetry"
+    echo "→ Updating Python dependencies with Poetry"
+    poetry update
 elif [ -f "Pipfile" ] && command_exists pipenv; then
-    run_command "pipenv update" "Updating Python dependencies with Pipenv"
+    echo "→ Updating Python dependencies with Pipenv"
+    pipenv update
 fi
 
 # Ruby
 if [ -f "Gemfile" ]; then
-    run_command "bundle update" "Updating Ruby dependencies"
+    echo "→ Updating Ruby dependencies"
+    bundle update
 fi
 
 # .NET
@@ -46,7 +55,8 @@ if compgen -G "*.sln" > /dev/null || compgen -G "*.csproj" > /dev/null; then
     # Update NuGet packages
     if compgen -G "*.sln" > /dev/null; then
         for sln in *.sln; do
-            run_command "dotnet list \"$sln\" package --outdated" "Checking outdated packages"
+            echo "→ Checking outdated packages"
+            dotnet list "$sln" package --outdated
         done
     fi
     print_color yellow "Use 'dotnet add package <name>' to update specific packages"
@@ -54,13 +64,16 @@ fi
 
 # Go
 if [ -f "go.mod" ]; then
-    run_command "go get -u ./..." "Updating Go dependencies"
-    run_command "go mod tidy" "Tidying Go modules"
+    echo "→ Updating Go dependencies"
+    go get -u ./...
+    echo "→ Tidying Go modules"
+    go mod tidy
 fi
 
 # Rust
 if [ -f "Cargo.toml" ]; then
-    run_command "cargo update" "Updating Rust dependencies"
+    echo "→ Updating Rust dependencies"
+    cargo update
 fi
 
 # Run bootstrap to ensure everything is properly installed


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The example scripts had a quoting error when using `eval` within `run_command`. Rather than fixing it, I think it's better to just remove `run_command` and use `echo` statements.

## Changes

Removed `run_command`

## Did you write or update any docs for this change?

No, this is just a template repo and these are sample scripts.

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
