### PR TITLE
chore: configure dependency minimum release age / cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION

Adds a minimum release age ("cooldown") to this repo's package-manager
configuration so newly published dependency versions wait ~7 days before they
can be adopted. This reduces exposure to compromised or unstable packages that
are caught and unpublished shortly after release.

Applied per package manager found in the repo:
- Dependabot (.github/dependabot.yml): cooldown.default-days: 7 per ecosystem
- pnpm (pnpm-workspace.yaml): minimumReleaseAge: 10080 (minutes)
- npm (.npmrc): min-release-age=7 (days)
- yarn (.yarnrc.yml): npmMinimalAgeGate: "7d"
- bun (bunfig.toml): minimumReleaseAge = 604800 (seconds)
- uv (pyproject.toml): exclude-newer = "7 days"

Generated and verified with semgrep (package_managers.* rules); the check passes
after this change.